### PR TITLE
Removed dependency on RhinoScriptProcessor and index-based queries

### DIFF
--- a/javascript-console-repo/src/main/amp/config/alfresco/extension/fme-jsconsole-context.xml
+++ b/javascript-console-repo/src/main/amp/config/alfresco/extension/fme-jsconsole-context.xml
@@ -7,7 +7,6 @@
 		<property name="transactionService" ref="transactionService"/>
 		<property name="preRollScriptResource" value="classpath:de/fme/jsconsole/jsconsole-pre-roll-script.js" />
 		<property name="postRollScriptResource" value="classpath:de/fme/jsconsole/jsconsole-post-roll-script.js" />
-		<property name="rhinoScriptProcessor" ref="javaScriptProcessor" />
 	</bean>
 
 </beans>

--- a/javascript-console-repo/src/main/amp/config/alfresco/extension/templates/webscripts/de/fme/jsconsole/createscript.put.js
+++ b/javascript-console-repo/src/main/amp/config/alfresco/extension/templates/webscripts/de/fme/jsconsole/createscript.put.js
@@ -1,5 +1,5 @@
 
-var scriptFolder = search.xpathSearch("/app:company_home/app:dictionary/app:scripts")[0];
+var scriptFolder = companyhome.childrenByXPath("app:dictionary/app:scripts")[0];
 if (scriptFolder) {
 	var scriptNode = scriptFolder.createFile(args.name);
 	scriptNode.content = requestbody.content;

--- a/javascript-console-repo/src/main/amp/config/alfresco/extension/templates/webscripts/de/fme/jsconsole/listscripts.get.js
+++ b/javascript-console-repo/src/main/amp/config/alfresco/extension/templates/webscripts/de/fme/jsconsole/listscripts.get.js
@@ -24,7 +24,7 @@ function findScripts(folder) {
   return scriptlist;
 }
 
-var scriptFolder = search.xpathSearch("/app:company_home/app:dictionary/app:scripts")[0];
+var scriptFolder = companyhome.childrenByXPath("app:dictionary/app:scripts")[0];
 if (scriptFolder) {
 	model.scripts = jsonUtils.toJSONString(findScripts(scriptFolder));
 }


### PR DESCRIPTION
The ExecuteWebScript is currently hard-wired against the default RhinoScriptProcessor by the way the script is prepared for execution. With an adjustment that simply adds an import for the pre-roll script instead of resolving imports and merging, this hardwiring can be removed allowing the ExecuteWebScript and JS Console as a whole to be used with alternative script processor implementations (i.e. https://github.com/AFaust/alfresco-enhanced-script-environment).
Additionally, the JS Console currently requires the presence of an index-based search system to lookup and store scripts. This is not necessary for the purpose of locating a specific location as there are database-based alternatives, allowing the JS Console to be used when no index is available (either corrupt, being re-created or the "noindex" Search subsystem being used).
