### PR TITLE
Added /web to file mappings so the resources are available in share.war

### DIFF
--- a/javascript-console-share/src/main/amp/file-mapping.properties
+++ b/javascript-console-share/src/main/amp/file-mapping.properties
@@ -12,4 +12,4 @@ include.default=true
 # Custom mappings.  If 'include.default' is false, then this is the complete set.
 #
 #/WEB-INF=/WEB-INF
-#/web=/
+/web=/


### PR DESCRIPTION
I was building the amps from source. The Share amp doesn't work.  There are 2 directories in src/main/amp/web/components and src/main/amp/web/fme.  These aren't being copied by the MMT into the correct place.

I updated the file mappings and it seems to work.
