### PR TITLE
Fix to make 'run with var space - select' work in Alfresco 5.1+

### DIFF
--- a/javascript-console-share/src/main/amp/config/alfresco/site-webscripts/de/fme/components/jsconsole/javascript-console.get.head.ftl
+++ b/javascript-console-share/src/main/amp/config/alfresco/site-webscripts/de/fme/components/jsconsole/javascript-console.get.head.ftl
@@ -5,6 +5,7 @@
 <@script type="text/javascript" src="${page.url.context}/res/fme/components/jsconsole/javascript-console.js"></@script>
 <@link rel="stylesheet" type="text/css" href="${page.url.context}/res/modules/documentlibrary/global-folder.css" />
 <@script type="text/javascript" src="${page.url.context}/res/modules/documentlibrary/global-folder.js"></@script>
+<@script type="text/javascript" src="${page.url.context}/res/components/common/common-component-style-filter-chain.js"></@script>
 <@script type="text/javascript" src="${page.url.context}/res/fme/components/jsconsole/beautify.js"></@script>
 <@script type="text/javascript" src="${page.url.context}/res/yui/resize/resize.js"></@script>
 


### PR DESCRIPTION
Ref. https://github.com/atolcd/alfresco-share-import-export/issues/2