### PR TITLE
Strip dependencies to avoid library issues

### DIFF
--- a/javascript-console-repo/pom.xml
+++ b/javascript-console-repo/pom.xml
@@ -82,7 +82,80 @@
     <dependencies>
         <dependency>
             <groupId>${alfresco.groupId}</groupId>
+            <artifactId>alfresco-data-model</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.chemistry.opencmis</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tika</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>${alfresco.groupId}</groupId>
             <artifactId>alfresco-repository</artifactId>
+            <exclusions>
+                <!-- trim down artifacts as best as possible (speed up build + avoid accidental dependencies to specific Alfresco versions) -->
+                <exclusion>
+                    <groupId>org.alfresco</groupId>
+                    <artifactId>alfresco-legacy-lucene</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.alfresco</groupId>
+                    <artifactId>alfresco-jlan-embed</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.alfresco</groupId>
+                    <artifactId>alfresco-mbeans</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.alfresco</groupId>
+                    <artifactId>alfresco-text-gen</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.alfresco.services</groupId>
+                    <artifactId>alfresco-events</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.alfresco</groupId>
+                    <artifactId>alfresco-greenmail</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.chemistry.opencmis</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tika</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.poi</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.social</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/javascript-console-repo/src/main/amp/config/alfresco/module/de.fme.alfresco.JavascriptConsole-repo/module-context.xml
+++ b/javascript-console-repo/src/main/amp/config/alfresco/module/de.fme.alfresco.JavascriptConsole-repo/module-context.xml
@@ -21,7 +21,6 @@
         		<property name="renditionService" ref="RenditionService" />
         		<property name="ruleService" ref="RuleService" />
         		<property name="tagService" ref="TaggingService" />
-        		<property name="categoryService" ref="CategoryService" />
         		<property name="webDavService" ref="webdavService" />
         		<property name="auditService" ref="AuditService" />
         		<property name="sysAdminParams" ref="sysAdminParams" />

--- a/javascript-console-repo/src/main/java/de/fme/jsconsole/PerfLog.java
+++ b/javascript-console-repo/src/main/java/de/fme/jsconsole/PerfLog.java
@@ -5,7 +5,6 @@ package de.fme.jsconsole;
 
 import java.text.MessageFormat;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -20,7 +19,7 @@ import org.apache.commons.logging.LogFactory;
 public class PerfLog {
 
 	private static final int DEFAULT_ASSERT_PERFORMANCE = 2000;
-	private Log LOG = LogFactory.getLog(PerfLog.class);
+	private Log logger = LogFactory.getLog(PerfLog.class);
 	private long startTime;
 
 	/**
@@ -30,7 +29,7 @@ public class PerfLog {
 	 */
 	public PerfLog(Log logger) {
 		if (logger != null) {
-			LOG = logger;
+			this.logger = logger;
 		}
 	}
 
@@ -49,10 +48,8 @@ public class PerfLog {
 	 */
 	public PerfLog start(String message, Object... params) {
 		startTime = System.currentTimeMillis();
-		if (LOG.isInfoEnabled() || LOG.isWarnEnabled()) {
-			if (StringUtils.isNotEmpty(message)) {
-				LOG.info(MessageFormat.format(message, params));
-			}
+		if (logger.isInfoEnabled() && message != null && !message.trim().isEmpty()) {
+			logger.info(MessageFormat.format(message, params));
 		}
 		return this;
 	}
@@ -73,13 +70,11 @@ public class PerfLog {
 	public long stop(int assertPerformanceOf, String message, Object... params) {
 		long endTime = System.currentTimeMillis();
 		long neededTime = endTime - startTime;
-		if (LOG.isInfoEnabled() || LOG.isWarnEnabled()) {
-			if (neededTime < assertPerformanceOf) {
-				LOG.info("(OK) " + neededTime + " ms:" + MessageFormat.format(message, params));
-			} else {
-				LOG.warn("(WARNING) " + neededTime + " ms: " + MessageFormat.format(message, params));
-			}
-
+		boolean inTime = neededTime < assertPerformanceOf;
+        if (logger.isInfoEnabled() && inTime) {
+			logger.info("(OK) " + neededTime + " ms:" + MessageFormat.format(message, params));
+		} else if (logger.isWarnEnabled() && !inTime){
+			logger.warn("(WARNING) " + neededTime + " ms: " + MessageFormat.format(message, params));
 		}
 		return neededTime;
 


### PR DESCRIPTION
This PR excludes various unneeded dependencies in the Repository module and replaces use of commons-lang, commons-io and guava to a) be compatible with ACS 7, b) reduce the number of 3rd party library use flagged by the [Alfresco Extension Inspector](https://github.com/Alfresco/alfresco-extension-inspector/), and c) solve an issue with no longer resolveable Spring Social RC versions (Alfresco has deleted artifacts in their Nexus).

Trimmong down the dependencies could have been done way more aggressively / granularly, but for the sake of review and to avoid accidental secondary issues, this PR only excludes those dependencies which add large sets of transitive dependencies or which are directly related to 3rd party library flagged by the extension inspector.

Fixes #96 
Fixes #95 