### PR TITLE
fix: check and process "json[i]" type correctly (printDumpInfos function)

### DIFF
--- a/javascript-console-share/src/main/amp/web/fme/components/jsconsole/javascript-console.js
+++ b/javascript-console-share/src/main/amp/web/fme/components/jsconsole/javascript-console.js
@@ -1730,7 +1730,8 @@ if (typeof String.prototype.startsWith != 'function') {
           var rows = new Map();
 
           for ( var i = 0; i < json.length; i++) {
-              var dump = JSON.parse(json[i]);
+              var dumpData = (typeof json[i]!='object'?json[i]:json[i].json);
+              var dump = JSON.parse(dumpData);
               myColumnDefs.push({key:i+" "+dump.properties["cm:name"]+" ("+dump.nodeRef+")", resizeable: true, minWidth: 200, formatter:formatterDispatcher,editor:new YAHOO.widget.BaseCellEditor()});
               reponseFields.push(i+" "+dump.properties["cm:name"]+" ("+dump.nodeRef+")");
 


### PR DESCRIPTION


If a document is "preselected" for the JS-Console through the "use/dump in javascript console" , the entries of the json array differ in types. If an "object" type is found, the underlying "json" property for parsing is used, otherwise the string. The problem occured in Alfresco 7.0.0